### PR TITLE
This fixes the infinite build problem.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ enableGraalNative=false
 gwtFrameworkVersion=2.11.0
 gwtPluginVersion=1.1.29
 gdxTeaVMVersion=1.0.0-b9
-teaVMVersion=0.10.0-dev-5
+teaVMVersion=0.9.2
 gdxVersion=1.12.1


### PR DESCRIPTION
gdx-teavm currently depends on an older, more stable TeaVM version (0.9.2) instead of what it used to depend on (0.10.0-dev-5, or some sub-version other than dev-5). Using 0.9.2 solves the infinite build issue and allows the game to be built. After you run `gradlew teavm:build` you can run it from the `teavm/build/dist/webapp/` folder.

I'll update gdx-liftoff soon to make TeaVM default to 0.9.2 .